### PR TITLE
Suggestion of behaviour change when correcting

### DIFF
--- a/languagetool-correction.el
+++ b/languagetool-correction.el
@@ -119,7 +119,7 @@ on OVERLAY."
               (read-char (languagetool-correction-parse-message ov)))
         (cond
          ((char-equal ?\s pressed-key)
-          (return 'quit))
+          (cl-return 'quit))
          (t
           (languagetool-correction-apply pressed-key ov)))))))
 

--- a/languagetool-correction.el
+++ b/languagetool-correction.el
@@ -80,7 +80,10 @@ Get the information about corrections from OVERLAY."
                       "]: Ignore  "))
     (setq msg (concat msg "["
                       (propertize "C-s" 'face 'font-lock-keyword-face)
-                      "]: Skip\n"))
+                      "]: Skip  "))
+    (setq msg (concat msg "["
+                      (propertize "SPC" 'face 'font-lock-keyword-face)
+                      "]: Quit\n"))
     msg))
 
 (defun languagetool-correction-apply (pressed-key overlay)
@@ -96,7 +99,7 @@ on OVERLAY."
    ((char-equal ?\C-s pressed-key)
     (goto-char (overlay-end overlay)))
    ((not (cl-position pressed-key languagetool-correction-keys))
-    (error "Key `%c' cannot be used" pressed-key))
+    (message "Key `%c' cannot be used" pressed-key))
    (t
     (let ((size (length (languagetool-core-get-replacements overlay)))
           (pos (cl-position pressed-key languagetool-correction-keys)))
@@ -114,7 +117,11 @@ on OVERLAY."
         (message nil)
         (setq pressed-key
               (read-char (languagetool-correction-parse-message ov)))
-        (languagetool-correction-apply pressed-key ov)))))
+        (cond
+         ((char-equal ?\s pressed-key)
+          (return 'quit))
+         (t
+          (languagetool-correction-apply pressed-key ov)))))))
 
 (provide 'languagetool-correction)
 

--- a/languagetool-correction.el
+++ b/languagetool-correction.el
@@ -99,7 +99,7 @@ on OVERLAY."
    ((char-equal ?\C-s pressed-key)
     (goto-char (overlay-end overlay)))
    ((not (cl-position pressed-key languagetool-correction-keys))
-    (message "Key `%c' cannot be used" pressed-key))
+    (error "Key `%c' cannot be used" pressed-key))
    (t
     (let ((size (length (languagetool-core-get-replacements overlay)))
           (pos (cl-position pressed-key languagetool-correction-keys)))

--- a/languagetool.el
+++ b/languagetool.el
@@ -114,17 +114,20 @@ checked."
     (setq languagetool-server-correction-p t))
   (condition-case err
       (progn
-        (dolist (ov (reverse (overlays-in (point-min)
+        (dolist (ov (reverse (overlays-in (point)
                                           (point-max))))
           (when (and (overlay-get ov 'languagetool-message)
                      (overlay-start ov))
             (goto-char (overlay-start ov))
-            (languagetool-correction-at-point)))
+            (when (eql 'quit
+                       (languagetool-correction-at-point))
+              (cl-return 'quit))))
         (message "End of corrections"))
     ((quit error)
      (when languagetool-server-mode
        (setq languagetool-server-correction-p nil))
-     (error "%s" (error-message-string err))))
+     (error "%s"
+            (error-message-string err))))
   (when languagetool-server-mode
     (setq languagetool-server-correction-p nil)))
 

--- a/languagetool.el
+++ b/languagetool.el
@@ -112,7 +112,7 @@ checked."
   (interactive)
   (when languagetool-server-mode
     (setq languagetool-server-correction-p t))
-  (condition-case err
+y  (condition-case err
       (unless (eql 'quit
                (dolist (ov (sort (overlays-in (point)
                                               (point-max))
@@ -129,7 +129,9 @@ checked."
      (when languagetool-server-mode
        (setq languagetool-server-correction-p nil))
      (error "%s"
-            (error-message-string err))))
+            (error-message-string err))
+     (--cl-block-nil--)
+     (message ("Quit"))))
   (when languagetool-server-mode
     (setq languagetool-server-correction-p nil)))
 

--- a/languagetool.el
+++ b/languagetool.el
@@ -114,8 +114,10 @@ checked."
     (setq languagetool-server-correction-p t))
   (condition-case err
       (unless (eql 'quit
-               (dolist (ov (reverse (overlays-in (point)
-                                                 (point-max))))
+               (dolist (ov (sort (overlays-in (point)
+                                              (point-max))
+                                 (lambda (x y) (< (overlay-start x)
+                                                  (overlay-start y)))))
                  (when (and (overlay-get ov 'languagetool-message)
                             (overlay-start ov))
                    (goto-char (overlay-start ov))

--- a/languagetool.el
+++ b/languagetool.el
@@ -113,16 +113,16 @@ checked."
   (when languagetool-server-mode
     (setq languagetool-server-correction-p t))
   (condition-case err
-      (progn
-        (dolist (ov (reverse (overlays-in (point)
-                                          (point-max))))
-          (when (and (overlay-get ov 'languagetool-message)
-                     (overlay-start ov))
-            (goto-char (overlay-start ov))
-            (when (eql 'quit
-                       (languagetool-correction-at-point))
-              (cl-return 'quit))))
-        (message "End of corrections"))
+      (unless (eql 'quit
+               (dolist (ov (reverse (overlays-in (point)
+                                                 (point-max))))
+                 (when (and (overlay-get ov 'languagetool-message)
+                            (overlay-start ov))
+                   (goto-char (overlay-start ov))
+                   (when (eql 'quit
+                              (languagetool-correction-at-point))
+                     (cl-return 'quit)))))
+        (message "Nothing left to correct"))
     ((quit error)
      (when languagetool-server-mode
        (setq languagetool-server-correction-p nil))

--- a/languagetool.el
+++ b/languagetool.el
@@ -113,12 +113,14 @@ checked."
   (when languagetool-server-mode
     (setq languagetool-server-correction-p t))
   (condition-case err
-      (save-excursion
-        (dolist (ov (reverse (overlays-in (point-min) (point-max))))
+      (progn
+        (dolist (ov (reverse (overlays-in (point-min)
+                                          (point-max))))
           (when (and (overlay-get ov 'languagetool-message)
                      (overlay-start ov))
             (goto-char (overlay-start ov))
-            (languagetool-correction-at-point))))
+            (languagetool-correction-at-point)))
+        (message "End of corrections"))
     ((quit error)
      (when languagetool-server-mode
        (setq languagetool-server-correction-p nil))


### PR DESCRIPTION
If I may suggest the following modifications:

1. Start correcting from point to the end of the buffer, receiving a message when there are no corrections left.
2. Press `SPC` to exit `languagetool-correct-buffer` without throwing an error.
3. Leave point at the place of the correction currently in view.

These changes yield a better workflow when doing manual corrections (in contrast to cases when accepting suggested corrections is sufficient).

This PR also corrects a bug with the overlays being scanned in the wrong order.