### PR TITLE
Escape docstring quotes

### DIFF
--- a/languagetool-core.el
+++ b/languagetool-core.el
@@ -175,12 +175,12 @@ A example hint function:
 \(defun hint-function ()
   \"Hint display function.\"
   (dolist (ov (overlays-at (point)))
-    (when (overlay-get ov 'languagetool-message)
+    (when (overlay-get ov \\='languagetool-message)
       (unless (current-message)
         (message
          \"%s%s\"
-         (overlay-get ov 'languagetool-short-message)
-         (if (/= 0 (length (overlay-get ov 'languagetool-replacements)))
+         (overlay-get ov \\='languagetool-short-message)
+         (if (/= 0 (length (overlay-get ov \\='languagetool-replacements)))
              (concat
               \" -> (\"
               (string-join (languagetool-core-get-replacements ov) \", \")


### PR DESCRIPTION
* languagetool-core.el (languagetool-hint-function): In Emacs 29+, byte compilation issues a warning when single quotes aren't escaped in docstrings.